### PR TITLE
Ff20 8 add support for x 11 x org

### DIFF
--- a/src/trackers/factory.py
+++ b/src/trackers/factory.py
@@ -7,7 +7,7 @@ Methods:
 """
 
 from .base import ActivityTracker
-from src.trackers import wayland
+from settings import Settings
 
 
 def get_activity_tracker(
@@ -25,13 +25,17 @@ def get_activity_tracker(
         if the system=="Linux".
     """
 
+    if Settings.DEBUG.value:
+        print(f"[DEBUG] (tracker.factory): session={session}")
+
     match system.capitalize():
         case "Linux":
-            if not session:
+            if session.lower() == "x11":
                 from src.trackers import x11
                 return x11.X11Tracker()
 
             if session.lower() == "wayland":
+                from src.trackers import wayland
                 return wayland.WaylandTracker()
 
         case "Windows":

--- a/src/trackers/x11.py
+++ b/src/trackers/x11.py
@@ -38,21 +38,20 @@ class X11Tracker(ActivityTracker):
         """Return True if user is active, False if idle."""
 
         if Settings.DEBUG.value:
-            idle_time = self.get_idle_time_s()
+            idle_time = self.get_idle_time_ms()
             print(
-                f"[DEBUG]: idle_for={idle_time} sec. is_active="
+                f"[DEBUG]: idle_for={idle_time:.2f} sec. is_active="
                 f"{idle_time <= Settings.I_MINUTES.value * 60}"
             )
 
-
-        return (time.time() - self.last_activity) <= Settings.I_MINUTES
+        return (self.get_idle_time_s()) <= Settings.I_MINUTES.value * 60
 
     def get_idle_time_ms(self) -> float:
         """Return idle time is ms according to DBus"""
 
-        return time.time() - self.last_activity
+        return (time.time() - self.last_activity) * 100
 
     def get_idle_time_s(self) -> float:
         """Return idle time is s according to DBus"""
 
-        return time.time() - self.last_activity / 1000.0
+        return time.time() - self.last_activity


### PR DESCRIPTION
# Brief description:
This pull request brings support for Linux xOrg (or X11) desktop environment support, alongside with small fixes.

# A change and its description:
1. __fix&feat__ (_`src/tracker/factory`_): Corrected the session variable name for the `X11` support. Added a debug printer, whenever the `settings.Settings.DEBUG=True`.
2. __fix__ (_`src/tracker/x11`_): Fixed issue with time counting, now seconds and milliseconds are counted correctly. Additionally, altered the formatter for the debug print.

# Deployment notes:
None.